### PR TITLE
chore: add Renovate config (soxhub baseline)

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,0 +1,7 @@
+{
+  "$schema": "https://docs.renovatebot.com/renovate-schema.json",
+  // Do not configure 'config:recommended' or 'minimumReleaseAge' - these are included in github>soxhub/renovate-config. See: https://github.com/soxhub/renovate-config
+  "extends": [
+    "github>soxhub/renovate-config"
+  ]
+}


### PR DESCRIPTION
We are updating the renovate configuration to use the standard baseline developed by Peter Waganet and his team as the source of truth for renovate settings, while also ensuring that current renovate configurations remain unchanged.\n\n**Change in this PR:** Added  extending .\n\nNo action required beyond review/merge. Existing repo-specific settings win on conflict.